### PR TITLE
feat: tag zettel

### DIFF
--- a/syn.ts
+++ b/syn.ts
@@ -116,7 +116,7 @@ const labZettel = (date: Date) =>
     fmtDate(date)
   }]]\n`;
 const tagZettel = (date: Date, tag: string) =>
-  `---\ndate: ${fmtTime(date)}\n---\n\n\n[[z:zettels?tag=${tag}&timeline]]\n`;
+  `---\ndate: ${fmtTime(date)}\n---\n\n\n[[z:zettels?tag=${tag.replaceAll("-","")}&timeline]]\n`;
 
 const args = parse(Deno.args);
 const typeArg = args["t"] || args["type"];


### PR DESCRIPTION
given an invocation like...

```sh
syn.ts -t tag systemd
```

...creates a zettel like...

```
---
date: 2021-03-27T14:17
---

[[z:zettels?tag=systemd&timeline]]
```

These zettels are useful for listing other entries tagged with a given phrase

Resolves #10 